### PR TITLE
feat(media): normalize media type to uppercase

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,19 @@
-import { NestFactory } from '@nestjs/core';
-import { AppModule } from './app.module';
+import { ValidationPipe } from "@nestjs/common";
+import { NestFactory } from "@nestjs/core";
+import { AppModule } from "./app.module";
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true, // remove props que não existem no DTO
+      transform: true, // aplica class-transformer antes da validação
+      transformOptions: {
+        enableImplicitConversion: true, // converte tipos primitivos automaticamente (opcional)
+      },
+      // forbidNonWhitelisted: true,  // descomente se quiser rejeitar requests com campos extras
+    }),
+  );
   await app.listen(process.env.PORT ?? 3000);
 }
 bootstrap();

--- a/src/media/base.controller.ts
+++ b/src/media/base.controller.ts
@@ -12,7 +12,6 @@ export abstract class BaseMediaController {
     const actotId = "60c72b9f9b1d8e0015f8e5b4";
     createMediaDto.createdBy = actotId;
     createMediaDto.updatedBy = actotId;
-    createMediaDto.type = String(createMediaDto.type || "").toUpperCase();
 
     return this.mediaService.create(createMediaDto);
   }

--- a/src/media/base.controller.ts
+++ b/src/media/base.controller.ts
@@ -1,17 +1,18 @@
-import { Body, Post, UseInterceptors } from '@nestjs/common';
+import { Body, Post, UseInterceptors } from "@nestjs/common";
 
-import { LoggingInterceptor } from '../log/interceptors/logging.interceptor';
-import { CreateMediaDto } from './dto/create-media.dto';
-import { MediaService } from './media.service';
+import { LoggingInterceptor } from "../log/interceptors/logging.interceptor";
+import { CreateMediaDto } from "./dto/create-media.dto";
+import { MediaService } from "./media.service";
 
 export abstract class BaseMediaController {
   constructor(protected readonly mediaService: MediaService) {}
   @Post()
   @UseInterceptors(LoggingInterceptor)
   async create(@Body() createMediaDto: CreateMediaDto) {
-    const actotId = '60c72b9f9b1d8e0015f8e5b4';
+    const actotId = "60c72b9f9b1d8e0015f8e5b4";
     createMediaDto.createdBy = actotId;
     createMediaDto.updatedBy = actotId;
+    createMediaDto.type = String(createMediaDto.type || "").toUpperCase();
 
     return this.mediaService.create(createMediaDto);
   }

--- a/src/media/dto/create-media.dto.ts
+++ b/src/media/dto/create-media.dto.ts
@@ -1,8 +1,9 @@
-import { IsEnum, IsNotEmpty, IsString, IsUrl } from 'class-validator';
+import { Transform } from "class-transformer";
+import { IsEnum, IsNotEmpty, IsString, IsUrl } from "class-validator";
 
 enum MediaType {
-  VIDEO = 'VIDEO',
-  NEWS = 'NEWS',
+  VIDEO = "VIDEO",
+  NEWS = "NEWS",
 }
 export class CreateMediaDto {
   @IsNotEmpty()
@@ -14,8 +15,11 @@ export class CreateMediaDto {
   url: string;
 
   @IsNotEmpty()
+  @Transform(({ value }) =>
+    typeof value === "string" ? value.toUpperCase() : value,
+  )
   @IsEnum(MediaType, {
-    message: 'type must be either VIDEO or NEWS',
+    message: "type must be either VIDEO or NEWS",
   })
   type: MediaType;
 


### PR DESCRIPTION
### O quê
Converte valores do campo `type` para maiúsculas antes da validação e habilita `ValidationPipe` global com `transform: true`.

### Porque
Permite aceitar `video`, `Video`, `VIDEO` do cliente e armazenar/validar sempre `VIDEO` — evita falhas de validação e inconsistência no DB.

### Testes
1. POST /media com body: {"title":"x","url":"https://...","type":"video"} → deve validar e salvar com `type: "VIDEO"`.
2. Inputs inválidos (ex.: "typo") continuam a falhar.

### Notas de migração
Nenhuma migração obrigatória no DB — mudança é apenas na validação/transformação do input.
